### PR TITLE
RC4 fixes timeout during testing

### DIFF
--- a/bin/mplx_qc.py
+++ b/bin/mplx_qc.py
@@ -26,7 +26,7 @@ import openpyxl
 from dump_js_barcodes import Merge
 from dump_js_barcodes import SequencingEvent
 
-__version__ = '1.0.0-rc3'
+__version__ = '1.0.0-rc4'
 
 logger = logging.getLogger(__name__)
 

--- a/tests/mplx_qc/test_mplx_qc.py
+++ b/tests/mplx_qc/test_mplx_qc.py
@@ -88,7 +88,7 @@ def run_qc(tmpdir, input_path):
     convert_tsv(RESOURCE_BASE/input_path, xlsx_path)
     args = [SCRIPT_PATH, xlsx_path]
     cp = run(args, stdin=DEVNULL, stdout=PIPE, stderr=PIPE,
-             universal_newlines=True, timeout=2)
+             universal_newlines=True, timeout=10)
     print(cp.stdout)
     print(cp.stderr, file=sys.stderr)
     return cp

--- a/tests/mplx_qc/test_mplx_qc.py
+++ b/tests/mplx_qc/test_mplx_qc.py
@@ -88,7 +88,7 @@ def run_qc(tmpdir, input_path):
     convert_tsv(RESOURCE_BASE/input_path, xlsx_path)
     args = [SCRIPT_PATH, xlsx_path]
     cp = run(args, stdin=DEVNULL, stdout=PIPE, stderr=PIPE,
-             universal_newlines=True, timeout=10)
+             universal_newlines=True, timeout=20)
     print(cp.stdout)
     print(cp.stderr, file=sys.stderr)
     return cp


### PR DESCRIPTION
When testing on the cluster, we need to give more time for the functional tests for Python to start up.