### PR TITLE
Update deprecated get_sheet_by_name method

### DIFF
--- a/bin/dump_xl_bam_paths.py
+++ b/bin/dump_xl_bam_paths.py
@@ -6,7 +6,7 @@ import openpyxl
 
 
 wb = openpyxl.load_workbook(sys.argv[1])
-sheet = wb.get_sheet_by_name('smpls')
+sheet = wb['smpls']
 active_sheet = wb.active
 assert sheet == active_sheet, (sheet.title, active_sheet.title)
 row_iter = iter(active_sheet.rows)

--- a/bin/dump_xl_barcodes.py
+++ b/bin/dump_xl_barcodes.py
@@ -6,7 +6,7 @@ import openpyxl
 
 
 wb = openpyxl.load_workbook(sys.argv[1])
-sheet = wb.get_sheet_by_name('smpls')
+sheet = wb['smpls']
 active_sheet = wb.active
 assert sheet == active_sheet, (sheet.title, active_sheet.title)
 row_iter = iter(active_sheet.rows)

--- a/bin/dump_xl_cram_paths.py
+++ b/bin/dump_xl_cram_paths.py
@@ -6,7 +6,7 @@ import openpyxl
 
 
 wb = openpyxl.load_workbook(sys.argv[1])
-sheet = wb.get_sheet_by_name('smpls')
+sheet = wb['smpls']
 active_sheet = wb.active
 assert sheet == active_sheet, (sheet.title, active_sheet.title)
 row_iter = iter(active_sheet.rows)

--- a/bin/mplx_qc.py
+++ b/bin/mplx_qc.py
@@ -187,7 +187,7 @@ def generate_xlsx_rows(input_path):
     worksheet."""
     wb = openpyxl.load_workbook(str(input_path),
                                 data_only=True, read_only=True)
-    sheet = wb.get_sheet_by_name('smpls')
+    sheet = wb['smpls']
     active_sheet = wb.active
     assert sheet == active_sheet, (sheet.title, active_sheet.title)
     logger.debug('active_sheet name: %s', active_sheet.title)


### PR DESCRIPTION
- openpyxl's deprecated wb.get_sheet_by_name method is now replaced with wb[sheetname] per [documentation](https://openpyxl.readthedocs.io/en/stable/api/openpyxl.workbook.workbook.html)