### PR TITLE
Update ERROR prefixes

### DIFF
--- a/tests/mplx_qc/test_mplx_qc.py
+++ b/tests/mplx_qc/test_mplx_qc.py
@@ -400,8 +400,6 @@ def test_hgv19_merge_ec5_unit(capsys):
 
 def check_run_qc(capsys, num_errs, error_prefix, expected_out_path):
     out, err = capsys.readouterr()
-    print(out)
-    print(err, file=sys.stderr)
     error_lines = err.splitlines()
     assert any(error_prefix in s for s in error_lines)
     assert len(error_lines) == num_errs


### PR DESCRIPTION
Due to the nature of some of these errors, they will naturally return more than one.

For example `test_hgv19_merge_ec5_unit` though ideally would we want to check just the `CRAM and JSON have different sample names`, the cause of that error is a chain reaction resulting of many errors logged throughout the way. I listed them in test docstring to make it clear.

Because of this, `check_run_qc` cannot assume that will be the only error therefore i switched it where if any of the errors matched the passed `error_prefix` it should pass.

Notes/Comments:
- `test_hgv19_merge_ec21_event_id_unit` is still failing because there is no data in the expect.tsv
- `test_hgv19_merge_ec21_library_name_unit` is still failing. I was following the path and I do not see how `JSON has wrong keys` is raised. Line 337 in `mplx_qc.py` raises error_code 21 but does not pass the same message. The test is also changing the key `library_name`. Line 336 only checks for the key `id` so this issue wont even raise. I'm not sure if this is a bug in the code or a misunderstanding in the test.

So should `test_hgv19_merge_ec21_library_name_unit` check for the `JSON has wrong keys` (then the code itself should be edited) or since it's dealing with `library_name` just check for `key 'library_name' in Merge is missing` error (only test will need to be edited).