### PR TITLE
Issue 22/refactor scripts for entry points

### DIFF
--- a/bin/cram_rg_check.sh
+++ b/bin/cram_rg_check.sh
@@ -4,7 +4,6 @@ workbook="$1"
 
 BIN_DIR=~/bin
 
-
 "$BIN_DIR"/dump_xl_cram_paths.py "$workbook" 2>&1 |
     tr \\n \\0 |
     xargs -0 -n1 samtools view -H |

--- a/bin/cram_rg_check.sh
+++ b/bin/cram_rg_check.sh
@@ -4,8 +4,9 @@ workbook="$1"
 
 BIN_DIR=~/bin
 
-"$BIN_DIR"/dump_xl_cram_paths.py "$workbook" |
+
+"$BIN_DIR"/dump_xl_cram_paths.py "$workbook" 2>&1 |
     tr \\n \\0 |
     xargs -0 -n1 samtools view -H |
     "$BIN_DIR"/dump_rgs.py |
-    diff - <("$BIN_DIR"/dump_xl_barcodes.py "$workbook")
+    diff - <("$BIN_DIR"/dump_xl_barcodes.py "$workbook" 2>&1)

--- a/bin/dump_rgs.py
+++ b/bin/dump_rgs.py
@@ -9,27 +9,19 @@ def main():
 
 
 def run():
-    # read file, get rg_bc, rg_sm
-    # filename = '20_rg.txt'
-    # with open(filename) as fin:
     for line in sys.stdin:
         linesplit = line.rstrip().split('\t')
         if linesplit[0] != '@RG':
             continue
-        # print (linesplit)
         rg_dict = {}
         for item in linesplit[1:]:
             k, v = item.split(':', 1)
             assert k not in rg_dict, (k, rg_dict)
             assert ':' not in k
             rg_dict[k] = v
-        # print(rg_dict.items())
-        # update rg_bc for new HgV 17.5
         pat = re.compile(r'PU:(?:[\w-]+_)?([\w-]+)')
         rg_bc = pat.search(line).group(1)
-        # rg_bc = rg_dict['PU']
         rg_sm = rg_dict['SM']
-        #  print('PU: %s SM: %s' % (rg_bc, rg_sm))
         print(rg_bc, rg_sm, sep='\t')
 
 

--- a/bin/dump_rgs.py
+++ b/bin/dump_rgs.py
@@ -1,5 +1,7 @@
 #! /usr/bin/env python3
 
+""" Reads the input text and returns the SM and PU."""
+
 import re
 import sys
 

--- a/bin/dump_rgs.py
+++ b/bin/dump_rgs.py
@@ -3,25 +3,35 @@
 import re
 import sys
 
-# read file, get rg_bc, rg_sm
-# filename = '20_rg.txt'
-# with open(filename) as fin:
-for line in sys.stdin:
-    linesplit = line.rstrip().split('\t')
-    if linesplit[0] != '@RG':
-        continue
-    # print (linesplit)
-    rg_dict = {}
-    for item in linesplit[1:]:
-        k, v = item.split(':', 1)
-        assert k not in rg_dict, (k, rg_dict)
-        assert ':' not in k
-        rg_dict[k] = v
-    # print(rg_dict.items())
-    # update rg_bc for new HgV 17.5
-    pat = re.compile(r'PU:(?:[\w-]+_)?([\w-]+)')
-    rg_bc = pat.search(line).group(1)
-    # rg_bc = rg_dict['PU']
-    rg_sm = rg_dict['SM']
-    #  print('PU: %s SM: %s' % (rg_bc, rg_sm))
-    print(rg_bc, rg_sm, sep='\t')
+
+def main():
+    run()
+
+
+def run():
+    # read file, get rg_bc, rg_sm
+    # filename = '20_rg.txt'
+    # with open(filename) as fin:
+    for line in sys.stdin:
+        linesplit = line.rstrip().split('\t')
+        if linesplit[0] != '@RG':
+            continue
+        # print (linesplit)
+        rg_dict = {}
+        for item in linesplit[1:]:
+            k, v = item.split(':', 1)
+            assert k not in rg_dict, (k, rg_dict)
+            assert ':' not in k
+            rg_dict[k] = v
+        # print(rg_dict.items())
+        # update rg_bc for new HgV 17.5
+        pat = re.compile(r'PU:(?:[\w-]+_)?([\w-]+)')
+        rg_bc = pat.search(line).group(1)
+        # rg_bc = rg_dict['PU']
+        rg_sm = rg_dict['SM']
+        #  print('PU: %s SM: %s' % (rg_bc, rg_sm))
+        print(rg_bc, rg_sm, sep='\t')
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/dump_xl_bam_paths.py
+++ b/bin/dump_xl_bam_paths.py
@@ -1,20 +1,60 @@
 #! /usr/bin/env python3
 
-import sys
+"""Output the bam paths of a workbook file."""
+
+import argparse
+import logging
 
 import openpyxl
 
+logger = logging.getLogger(__name__)
 
-wb = openpyxl.load_workbook(sys.argv[1])
-sheet = wb['smpls']
-active_sheet = wb.active
-assert sheet == active_sheet, (sheet.title, active_sheet.title)
-row_iter = iter(active_sheet.rows)
-header_row = next(row_iter)
-column_names = [c.value for c in header_row]
-records = [
-    dict((k, v.value) for k, v in zip(column_names, row) if k in ('bam_path',))
-    for row in row_iter
-]
-for record in records:
-    print(record['bam_path'], sep='\t')
+__version__ = "1.0.0"
+
+
+def main():
+    args = parse_args()
+    configure_logging(args.verbose)
+    run(args.input_file)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input_file", help="an XLSX workbook")
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", help="increase output verbosity"
+    )
+    parser.add_argument(
+        "--version", action="version", version="%(prog)s {}".format(__version__)
+    )
+    args = parser.parse_args()
+    return args
+
+
+def configure_logging(verbose):
+    global logger
+    level = logging.DEBUG if verbose else logging.INFO
+    err_handler = logging.StreamHandler()
+    logger = logging.getLogger("dump_xl_bam_paths")
+    logger.addHandler(err_handler)
+    logger.setLevel(level)
+
+
+def run(input_file):
+    wb = openpyxl.load_workbook(input_file)
+    sheet = wb["smpls"]
+    active_sheet = wb.active
+    assert sheet == active_sheet, (sheet.title, active_sheet.title)
+    row_iter = iter(active_sheet.rows)
+    header_row = next(row_iter)
+    column_names = [c.value for c in header_row]
+    records = [
+        dict((k, v.value) for k, v in zip(column_names, row) if k in ("bam_path",))
+        for row in row_iter
+    ]
+    for record in records:
+        logger.info(record["bam_path"])
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/dump_xl_barcodes.py
+++ b/bin/dump_xl_barcodes.py
@@ -1,20 +1,64 @@
 #! /usr/bin/env python3
 
-import sys
+"""Outputs the barcodes of a workbook file."""
+
+import argparse
+import logging
 
 import openpyxl
 
+logger = logging.getLogger(__name__)
 
-wb = openpyxl.load_workbook(sys.argv[1])
-sheet = wb['smpls']
-active_sheet = wb.active
-assert sheet == active_sheet, (sheet.title, active_sheet.title)
-row_iter = iter(active_sheet.rows)
-header_row = next(row_iter)
-column_names = [c.value for c in header_row]
-records = [
-    dict((k, v.value) for k, v in zip(column_names, row) if k in ('lane_barcode', 'sample_id_nwd_id'))
-    for row in row_iter
-]
-for record in records:
-    print(record['lane_barcode'], record['sample_id_nwd_id'], sep='\t')
+__version__ = "1.0.0"
+
+
+def main():
+    args = parse_args()
+    config_logging(args.verbose)
+    run(args.input_file)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input_file", help="an XLSX workbook")
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", help="increase output verbosity"
+    )
+    parser.add_argument(
+        "--version", action="version", version="%(prog)s {}".format(__version__)
+    )
+    args = parser.parse_args()
+    return args
+
+
+def config_logging(verbose):
+    global logger
+    level = logging.DEBUG if verbose else logging.INFO
+    err_handler = logging.StreamHandler()
+    logger = logging.getLogger("dump_xl_barcodes")
+    logger.addHandler(err_handler)
+    logger.setLevel(level)
+
+
+def run(input_file):
+    wb = openpyxl.load_workbook(input_file)
+    sheet = wb["smpls"]
+    active_sheet = wb.active
+    assert sheet == active_sheet, (sheet.title, active_sheet.title)
+    row_iter = iter(active_sheet.rows)
+    header_row = next(row_iter)
+    column_names = [c.value for c in header_row]
+    records = [
+        dict(
+            (k, v.value)
+            for k, v in zip(column_names, row)
+            if k in ("lane_barcode", "sample_id_nwd_id")
+        )
+        for row in row_iter
+    ]
+    for record in records:
+        logger.info(f"{record['lane_barcode']} \t {record['sample_id_nwd_id']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/dump_xl_cram_paths.py
+++ b/bin/dump_xl_cram_paths.py
@@ -1,20 +1,60 @@
 #! /usr/bin/env python3
 
-import sys
+"""Outputs the cram paths of a workbook file."""
+
+import argparse
+import logging
 
 import openpyxl
 
+logger = logging.getLogger(__name__)
 
-wb = openpyxl.load_workbook(sys.argv[1])
-sheet = wb['smpls']
-active_sheet = wb.active
-assert sheet == active_sheet, (sheet.title, active_sheet.title)
-row_iter = iter(active_sheet.rows)
-header_row = next(row_iter)
-column_names = [c.value for c in header_row]
-records = [
-    dict((k, v.value) for k, v in zip(column_names, row) if k in ('cram_path',))
-    for row in row_iter
-]
-for record in records:
-    print(record['cram_path'], sep='\t')
+__version__ = "1.0.0"
+
+
+def main():
+    args = parse_args()
+    config_logging(args.verbose)
+    run(args.input_file)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input_file", help="an XLSX workbook")
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", help="increase output verbosity"
+    )
+    parser.add_argument(
+        "--version", action="version", version="%(prog)s {}".format(__version__)
+    )
+    args = parser.parse_args()
+    return args
+
+
+def config_logging(verbose):
+    global logger
+    err_handler = logging.StreamHandler()
+    level = logging.DEBUG if verbose else logging.INFO
+    logger = logging.getLogger("dump_xl_cram_paths")
+    logger.addHandler(err_handler)
+    logger.setLevel(level)
+
+
+def run(input_file):
+    wb = openpyxl.load_workbook(input_file)
+    sheet = wb["smpls"]
+    active_sheet = wb.active
+    assert sheet == active_sheet, (sheet.title, active_sheet.title)
+    row_iter = iter(active_sheet.rows)
+    header_row = next(row_iter)
+    column_names = [c.value for c in header_row]
+    records = [
+        dict((k, v.value) for k, v in zip(column_names, row) if k in ("cram_path",))
+        for row in row_iter
+    ]
+    for record in records:
+        logger.info(record["cram_path"])
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/rg_check.sh
+++ b/bin/rg_check.sh
@@ -4,8 +4,8 @@ workbook="$1"
 
 BIN_DIR=~/bin
 
-"$BIN_DIR"/dump_xl_bam_paths.py "$workbook" |
+"$BIN_DIR"/dump_xl_bam_paths.py "$workbook" 2>&1 |
     tr \\n \\0 |
     xargs -0 -n1 samtools view -H |
     "$BIN_DIR"/dump_rgs.py |
-    diff - <("$BIN_DIR"/dump_xl_barcodes.py "$workbook")
+    diff - <("$BIN_DIR"/dump_xl_barcodes.py "$workbook" 2>&1 )


### PR DESCRIPTION
Refactored 
- dump_xl_cram_paths.py
- dump_xl_barcodes.py
- dump_xl_bam_path.py
- dump_rgs.py
To have main methods so packaging can then have an entry point.

Since the output was changed to `logging` instead of just `print`, updated the bash scripts `cram_rg_check.sh` and `rg_check.sh` to capture the output of the python scripts.