### PR TITLE
Issue 16/fix pytest fail

### DIFF
--- a/ngsi_pm_py/ngsi_pm_py/mplx_qc.py
+++ b/ngsi_pm_py/ngsi_pm_py/mplx_qc.py
@@ -62,8 +62,10 @@ def config_logging(args):
         level = logging.INFO
     else:
         level = logging.DEBUG
-    logging.basicConfig(level=level)
     logger = logging.getLogger('mplx_qc')
+    err_handler = logging.StreamHandler()
+    logger.addHandler(err_handler)
+    logger.setLevel(level)
 
 
 def run_qc(input_file):

--- a/ngsi_pm_py/tests/mplx_qc/test_mplx_qc.py
+++ b/ngsi_pm_py/tests/mplx_qc/test_mplx_qc.py
@@ -21,7 +21,7 @@ def test_ec0(tmpdir):
 def test_ec2(tmpdir):
     cp = run_mplx_qc_xlsx(tmpdir, 'tsv_jwatt/ec_2_b.xlsx.tsv')
     check_output(cp, 2, 3,
-                 'ERROR:mplx_qc:CRAM and JSON '
+                 'CRAM and JSON '
                  'have mismatching sets of barcodes.',
                  RESOURCE_BASE/'tsv_jwatt/ec_2_expect.tsv')
 
@@ -34,35 +34,35 @@ def test_ec3(tmpdir):
     impossible."""
     cp = run_mplx_qc_xlsx(tmpdir, 'tsv_jwatt/ec_3_b.xlsx.tsv')
     check_output(cp, 3, 3,
-                 'ERROR:mplx_qc:Duplicate barcodes in JSON.',
+                 'Duplicate barcodes in JSON.',
                  RESOURCE_BASE/'tsv_jwatt/ec_3_expect.tsv')
 
 
 def test_ec4(tmpdir):
     cp = run_mplx_qc_xlsx(tmpdir, 'tsv_main/ec_4.xlsx.tsv')
     check_output(cp, 4, 1,
-                 'ERROR:mplx_qc:Duplicate barcodes in CRAM.',
+                 'Duplicate barcodes in CRAM.',
                  RESOURCE_BASE/'tsv_main/ec_4_expect.tsv')
 
 
 def test_ec5(tmpdir):
     cp = run_mplx_qc_xlsx(tmpdir, 'tsv_jwatt/ec_5_b.xlsx.tsv')
     check_output(cp, 5, 3,
-                 'ERROR:mplx_qc:CRAM and JSON have different sample names.',
+                 'CRAM and JSON have different sample names.',
                  RESOURCE_BASE/'tsv_jwatt/ec_5_expect.tsv')
 
 
 def test_ec6(tmpdir):
     cp = run_mplx_qc_xlsx(tmpdir, 'tsv_main/ec_6.xlsx.tsv')
     check_output(cp, 6, 1,
-                 'ERROR:mplx_qc:CRAM has wrong sample name.',
+                 'CRAM has wrong sample name.',
                  RESOURCE_BASE/'tsv_main/ec_6_expect.tsv')
 
 
 def test_ec7(tmpdir):
     cp = run_mplx_qc_xlsx(tmpdir, 'tsv_main/ec_7.xlsx.tsv')
     check_output(cp, 7, 1,
-                 'ERROR:mplx_qc:CRAM contains multiple values for sample.',
+                 'CRAM contains multiple values for sample.',
                  RESOURCE_BASE/'tsv_main/ec_7_expect.tsv')
 
 
@@ -74,7 +74,7 @@ def test_ec0_tsv():
 def test_ec7_tsv():
     cp = run_mplx_qc(RESOURCE_BASE/'tsv_main/ec_7.xlsx.tsv')
     check_output(cp, 7, 1,
-                 'ERROR:mplx_qc:CRAM contains multiple values for sample.',
+                 'CRAM contains multiple values for sample.',
                  RESOURCE_BASE/'tsv_main/ec_7_expect.tsv')
 
 

--- a/ngsi_pm_py/tests/mplx_qc/test_mplx_qc.py
+++ b/ngsi_pm_py/tests/mplx_qc/test_mplx_qc.py
@@ -134,160 +134,157 @@ def test_ec0_unit(capsys):
     assert error_code == 0
 
 
-def test_ec2_unit(capsys):
+def test_ec2_unit(capsys, caplog):
     error_code = mplx_qc.run_qc(str(RESOURCE_BASE/'tsv_jwatt/ec_2_b.xlsx.tsv'))
     assert error_code == 2
-    check_run_qc(capsys, 3,
+    check_run_qc(capsys, caplog, 3,
                  'CRAM and JSON have mismatching sets of barcodes.',
                  RESOURCE_BASE/'tsv_jwatt/ec_2_expect.tsv')
 
 
-def test_ec4_unit(capsys):
+def test_ec4_unit(capsys, caplog):
     error_code = mplx_qc.run_qc(str(RESOURCE_BASE/'tsv_main/ec_4.xlsx.tsv'))
     assert error_code == 4
-    check_run_qc(capsys, 1,
+    check_run_qc(capsys, caplog, 1,
                  'Duplicate barcodes in CRAM.',
                  RESOURCE_BASE/'tsv_main/ec_4_expect.tsv')
 
 
-def test_ec5_unit(capsys):
+def test_ec5_unit(capsys, caplog):
     error_code = mplx_qc.run_qc(str(RESOURCE_BASE/'tsv_jwatt/ec_5_b.xlsx.tsv'))
     assert error_code == 5
-    check_run_qc(capsys, 3,
+    check_run_qc(capsys, caplog, 3,
                  'CRAM and JSON have different sample names.',
                  RESOURCE_BASE/'tsv_jwatt/ec_5_expect.tsv')
 
 
-def test_ec6_unit(capsys):
+def test_ec6_unit(capsys, caplog):
     error_code = mplx_qc.run_qc(str(RESOURCE_BASE/'tsv_main/ec_6.xlsx.tsv'))
     assert error_code == 6
-    check_run_qc(capsys, 1,
+    check_run_qc(capsys, caplog, 1,
                  'CRAM has wrong sample name.',
                  RESOURCE_BASE/'tsv_main/ec_6_expect.tsv')
 
 
-def test_ec7_unit(capsys):
+def test_ec7_unit(capsys, caplog):
     error_code = mplx_qc.run_qc(str(RESOURCE_BASE/'tsv_main/ec_7.xlsx.tsv'))
     assert error_code == 7
-    check_run_qc(capsys, 1,
+    check_run_qc(capsys, caplog, 1,
                  'CRAM contains multiple values for sample.',
                  RESOURCE_BASE/'tsv_main/ec_7_expect.tsv')
 
 
-def test_ec9_unit(capsys):
+def test_ec9_unit(capsys, caplog):
     """If an RG in a CRAM file is missing a PU..."""
     error_code = mplx_qc.run_qc(str(RESOURCE_BASE/'tsv_main/ec_9.tsv'))
     assert error_code == 9
-    check_run_qc(capsys, 1,
+    check_run_qc(capsys, caplog, 1,
                  'An RG in the CRAM is missing its PU:',
                  RESOURCE_BASE/'tsv_main/ec_9_expect.tsv')
 
 
-def test_ec10_unit(capsys):
+def test_ec10_unit(capsys, caplog):
     """If an RG in a CRAM file is missing an SM..."""
     error_code = mplx_qc.run_qc(str(RESOURCE_BASE/'tsv_main/ec_10.tsv'))
     assert error_code == 10
-    check_run_qc(capsys, 1,
+    check_run_qc(capsys, caplog, 1,
                  'An RG in the CRAM is missing its SM:',
                  RESOURCE_BASE/'tsv_main/ec_10_expect.tsv')
 
 
-def test_ec12_unit(capsys):
+def test_ec12_unit(capsys, caplog):
     """If a JSON file is too bad to read..."""
     error_code = mplx_qc.run_qc(str(RESOURCE_BASE/'tsv_main/ec_12.tsv'))
     assert error_code == 12
-    check_run_qc(capsys, 1,
+    check_run_qc(capsys, caplog, 1,
                  'JSON is bad:',
                  RESOURCE_BASE/'tsv_main/ec_12_expect.tsv')
 
 
-def test_ec13_unit(capsys):
+def test_ec13_unit(capsys, caplog):
     """If a CRAM file is too bad to read..."""
     error_code = mplx_qc.run_qc(str(RESOURCE_BASE/'tsv_main/ec_13.tsv'))
     assert error_code == 13
-    check_run_qc(capsys, 1,
+    check_run_qc(capsys, caplog, 1,
                  'CRAM is bad:',
                  RESOURCE_BASE/'tsv_main/ec_13_expect.tsv')
 
 
-def test_ec14_unit(capsys):
+def test_ec14_unit(capsys, caplog):
     """If a JSON is missing or not a file..."""
     error_code = mplx_qc.run_qc(str(RESOURCE_BASE/'tsv_main/ec_14.tsv'))
     assert error_code == 14
-    check_run_qc(capsys, 1,
+    check_run_qc(capsys, caplog, 1,
                  'JSON is missing:',
                  RESOURCE_BASE/'tsv_main/ec_14_expect.tsv')
 
 
-def test_ec15_unit(capsys):
+def test_ec15_unit(capsys, caplog):
     """If a CRAM is missing or not a file..."""
     error_code = mplx_qc.run_qc(str(RESOURCE_BASE/'tsv_main/ec_15.tsv'))
     assert error_code == 15
-    check_run_qc(capsys, 1,
+    check_run_qc(capsys, caplog, 1,
                  'CRAM is missing:',
                  RESOURCE_BASE/'tsv_main/ec_15_expect.tsv')
 
 
-def test_ec17_unit(capsys):
+def test_ec17_unit(capsys, caplog):
     """If the input worklist file has bad contents..."""
     error_code = mplx_qc.run_qc(str(RESOURCE_BASE/'tsv_main/ec_17.tsv'))
     assert error_code == 17
-    check_run_qc(capsys, 1,
+    check_run_qc(capsys, caplog, 1,
                  'Input file has bad contents:',
                  RESOURCE_BASE/'empty_file')
 
 
-def test_ec17_xlsx_unit(capsys):
+def test_ec17_xlsx_unit(capsys, caplog):
     """If the input worklist file has bad contents..."""
     error_code = mplx_qc.run_qc(str(RESOURCE_BASE/'bad.xlsx'))
     assert error_code == 17
-    check_run_qc(capsys, 1,
+    check_run_qc(capsys, caplog, 1,
                  'Input file has bad contents:',
                  RESOURCE_BASE/'empty_file')
 
 
-def test_ec18_unit(capsys):
+def test_ec18_unit(capsys, caplog):
     """If the input worklist file has the wrong extension..."""
     error_code = mplx_qc.run_qc(str(RESOURCE_BASE/'foo.foo'))
     assert error_code == 18
-    check_run_qc(capsys, 1,
+    check_run_qc(capsys, caplog, 1,
                  'Input file has bad extension:',
                  RESOURCE_BASE/'empty_file')
 
 
-def test_ec19_unit(capsys):
+def test_ec19_unit(capsys, caplog):
     """If the input worklist file isn't a file..."""
     error_code = mplx_qc.run_qc(str(RESOURCE_BASE))
     assert error_code == 19
-    check_run_qc(capsys, 1,
+    check_run_qc(capsys, caplog, 1,
                  'Input is not a file:',
                  RESOURCE_BASE/'empty_file')
 
 
-def test_ec20_unit(capsys):
+def test_ec20_unit(capsys, caplog):
     """If the input worklist file doesn't even exist..."""
     error_code = mplx_qc.run_qc(str(RESOURCE_BASE/'foo.tsv'))
     assert error_code == 20
-    check_run_qc(capsys, 1,
+    check_run_qc(capsys, caplog, 1,
                  'Input file is missing:',
                  RESOURCE_BASE/'empty_file')
 
 
-def test_ec20_xlsx_unit(capsys):
+def test_ec20_xlsx_unit(capsys, caplog):
     """If the input worklist file doesn't even exist..."""
     error_code = mplx_qc.run_qc(str(RESOURCE_BASE/'foo.xlsx'))
     assert error_code == 20
-    check_run_qc(capsys, 1,
+    check_run_qc(capsys, caplog, 1,
                  'Input file is missing:',
                  RESOURCE_BASE/'empty_file')
 
 
-def check_run_qc(capsys, num_errs, error_prefix, expected_out_path):
+def check_run_qc(capsys, caplog, num_errs, error_prefix, expected_out_path):
     out, err = capsys.readouterr()
-    print(out)
-    print(err, file=sys.stderr)
-    error_lines = err.splitlines()
-    assert len(error_lines) == num_errs
-    for l in error_lines:
-        assert l.startswith(error_prefix)
     assert out == Path(expected_out_path).read_text()
+    assert len(caplog.records) == num_errs
+    for record in caplog.records:
+        assert record.msg.startswith(error_prefix)


### PR DESCRIPTION
Fixes the issue where if pytest is updated to the latest version, the test would not pass. 

- Uses the `caplog` fixture to test the errors that `mplx_qc` outputs
- Updates `check_output` to check the caplog records for correct error_prefix
- Updates `config_logging` to use the StreamHandler and remove formatting (basicconfig used some default formatting)